### PR TITLE
Microsoft Graph auth source and Additional templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+_Release: 2018-?
+
+* Template for YahooOIDC, MicrosoftOIDC, LinkedIn and Facebook
+* Add support for enabling http request/response logging
+* Add general debug information
+
+## v1.0.0
+
 _Released: 2018-?_
 
 * Generic OAuth2/OIDC module

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Almost all OAuth2/OIDC providers will require you to register a redirect URI. Us
 ## Provider specific Tips
 
  * [Google](/docs/GOOGLE.md)
+ * [Microsoft](/docs/MICROSOFT.md)
 
 ## Generic Usage
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Generic usage provides enough configuration parameters to use with any OAuth2 or
               // Enable logging of request/response. This *will* leak you client secret and tokens into the logs
               'logHttpTraffic' => true, //default is false
               'logMessageFormat' => 'A Guzzle MessageFormatter format string', // default setting is sufficient for most debugging
+              'logIdTokenJson' => true, //default false. Log the json in the ID token.
               
           ),
 ```

--- a/attributemap/facebook2name.php
+++ b/attributemap/facebook2name.php
@@ -1,0 +1,9 @@
+<?php
+
+$attributemap = array(
+    'facebook.first_name'  => 'givenName',
+    'facebook.last_name'   => 'sn',
+    'facebook.name'        => ['cn', 'displayName'],
+    'facebook.email'       => 'mail',
+    'facebook.id'           => 'uid',
+);

--- a/attributemap/microsoft2name.php
+++ b/attributemap/microsoft2name.php
@@ -1,0 +1,10 @@
+<?php
+
+$attributemap = array(
+    'microsoft.displayName' => 'displayName',
+    'microsoft.id' => 'uid',
+    'microsoft.mail' => 'mail',
+    'microsoft.surname' => 'sn',
+    'microsoft.givenName' => 'givenName',
+    'microsoft.name' => 'cn',
+);

--- a/docs/MICROSOFT.md
+++ b/docs/MICROSOFT.md
@@ -1,0 +1,64 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Microsoft as an AuthSource](#microsoft-as-an-authsource)
+- [Usage](#usage)
+  - [Recommended Config](#recommended-config)
+  - [Gotchas](#gotchas)
+- [Creating Microsoft Converged app](#creating-microsoft-converged-app)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Microsoft as an AuthSource
+
+Microsoft provides several APIs for logging users in. There is Graph v1 and v2, OpenID Connect and Live Connect.
+Live Connect is being deprecated. 
+The Graph apis allow you to specify if any user (both Consumer or Azure AD) can log in, just Consumer, just Azure AD or
+just a specific Azure AD tenant.
+
+
+# Usage
+## Recommended Config
+
+We ended up creating a sub class of the generic `authsource` called `MicrosoftHybridAuth`. This is because the OIDC `id_token`
+and the response from the graph api contain different sets of attributes. For example for consumer users (e.g. hotmail or outlook.com)
+the `id_token` will provide email but not first name and last name, while the graph api will provide first name and last name
+but not email. The subclass uses the profile data from the graph api and the email and full name from the OIDC `id_token`
+
+
+
+```php
+   //authsources.php
+   'microsoft' => [
+       'authoauth2:MicrosoftHybridAuth',
+       'clientId' => 'my-client',
+       'clientSecret' => 'eyM-mysecret'
+   ],
+```
+
+and if are using this with a SAML IdP then you can map the OIDC attributes to regular friendly names in your `authproc` section of `saml20-idp-hosted.php`.
+
+```php
+    // saml20-idp-hosted.php
+$metadata['myEntityId'] = array(			
+    'authproc' => array(
+        // Convert oidc names to ldap friendly names
+        90 => array('class' => 'core:AttributeMap',  'authoauth2:microsoft2name'),
+    ),
+   // other IdP config options
+)
+```
+## Gotchas
+
+* Azure AD only seems to return an email address if the user has an O365 subscription.
+* The Graph OIDC user info endpoint only returns a targeted `sub` id. The `id_token` has
+to be inspected to find the email address.
+
+
+# Creating Microsoft Converged app
+
+Visit https://apps.dev.microsoft.com and add a converged app.
+
+
+

--- a/lib/AttributeManipulator.php
+++ b/lib/AttributeManipulator.php
@@ -42,7 +42,7 @@ class AttributeManipulator
 
     /**
      * Attempt to stringify the input
-     * @param $input mixed if an array stringify the values, removing nullts
+     * @param $input mixed if an array stringify the values, removing nulls
      * @return array|string
      */
     protected function stringify($input) {

--- a/lib/Auth/Source/MicrosoftHybridAuth.php
+++ b/lib/Auth/Source/MicrosoftHybridAuth.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: patrick
+ * Date: 10/16/18
+ * Time: 1:34 PM
+ */
+
+namespace SimpleSAML\Module\authoauth2\Auth\Source;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Token\AccessToken;
+use SimpleSAML\Logger;
+use SimpleSAML\Module\authoauth2\ConfigTemplate;
+
+/**
+ * Microsoft seems to return some attributes in the ID token and some attributes in user profile call.
+ * This module combines the two
+ */
+class MicrosoftHybridAuth extends OAuth2
+{
+
+
+    /**
+     * MicrosoftHybridAuth constructor.
+     */
+    public function __construct(array $info, array $config)
+    {
+        // Set some defaults
+        if (!array_key_exists('template', $config)) {
+            $config['template'] = 'MicrosoftGraphV1';
+        }
+        parent::__construct($info, $config);
+    }
+
+
+    /**
+     * Extract some additional data from the id token and add it to the attributes
+     * @param AccessToken $accessToken
+     * @param AbstractProvider $provider
+     * @param array $state
+     */
+    protected function postFinalStep(AccessToken $accessToken, AbstractProvider $provider, &$state)
+    {
+        if (!array_key_exists('id_token', $accessToken->getValues())) {
+            Logger::warning('mshybridauth: ' . $this->getLabel() .  ' no id_token returned');
+            return;
+        }
+
+        $idTokenData = $this->extraIdTokenAttributes($accessToken->getValues()['id_token']);
+        $prefix = $this->config->getString('attributePrefix', '');
+
+        if (array_key_exists('email', $idTokenData)) {
+            $state['Attributes'][$prefix . 'mail'] = $idTokenData['email'];
+        }
+        if (array_key_exists('name', $idTokenData)) {
+            $state['Attributes'][$prefix . 'name'] = $idTokenData['name'];
+        }
+
+    }
+}

--- a/lib/Auth/Source/MicrosoftHybridAuth.php
+++ b/lib/Auth/Source/MicrosoftHybridAuth.php
@@ -20,7 +20,6 @@ use SimpleSAML\Module\authoauth2\ConfigTemplate;
 class MicrosoftHybridAuth extends OAuth2
 {
 
-
     /**
      * MicrosoftHybridAuth constructor.
      */
@@ -33,7 +32,6 @@ class MicrosoftHybridAuth extends OAuth2
         parent::__construct($info, $config);
     }
 
-
     /**
      * Extract some additional data from the id token and add it to the attributes
      * @param AccessToken $accessToken
@@ -43,7 +41,7 @@ class MicrosoftHybridAuth extends OAuth2
     protected function postFinalStep(AccessToken $accessToken, AbstractProvider $provider, &$state)
     {
         if (!array_key_exists('id_token', $accessToken->getValues())) {
-            Logger::warning('mshybridauth: ' . $this->getLabel() .  ' no id_token returned');
+            Logger::error('mshybridauth: ' . $this->getLabel() .  ' no id_token returned');
             return;
         }
 
@@ -51,10 +49,10 @@ class MicrosoftHybridAuth extends OAuth2
         $prefix = $this->config->getString('attributePrefix', '');
 
         if (array_key_exists('email', $idTokenData)) {
-            $state['Attributes'][$prefix . 'mail'] = $idTokenData['email'];
+            $state['Attributes'][$prefix . 'mail'] = [$idTokenData['email']];
         }
         if (array_key_exists('name', $idTokenData)) {
-            $state['Attributes'][$prefix . 'name'] = $idTokenData['name'];
+            $state['Attributes'][$prefix . 'name'] = [$idTokenData['name']];
         }
 
     }

--- a/lib/Auth/Source/OAuth2.php
+++ b/lib/Auth/Source/OAuth2.php
@@ -201,18 +201,21 @@ class OAuth2 extends \SimpleSAML_Auth_Source
         // We don't need to verify the signature on the id token since it was the token returned directly from
         // the OP over TLS
         $decoded = $this->extraAndDecodeJwtPayload($idToken);
+        if ($decoded == null) {
+            return [];
+        }
         $data = json_decode($decoded, true);
         //TODO: spec recommends checking that aud matches us and issuer is as expected.
         if ($data == null) {
-            Logger::warning("authoauth2: '$data' payload can't be decoded to json.");
-            return null;
+            Logger::warning("authoauth2: '$decoded' payload can't be decoded to json.");
+            return [];
         }
         return $data;
     }
 
     protected function extraAndDecodeJwtPayload($jwt) {
         $parts = explode('.', $jwt);
-        if (count($parts) < 3) {
+        if ($parts === false || count($parts) < 3) {
             Logger::warning("authoauth2: idToken '$jwt' is in unexpected format.");
             return null;
         }

--- a/lib/ConfigTemplate.php
+++ b/lib/ConfigTemplate.php
@@ -4,6 +4,25 @@ namespace SimpleSAML\Module\authoauth2;
 
 class ConfigTemplate {
 
+    const Facebook = [
+        'authoauth2:OAuth2',
+        // *** Facebook endpoints ***
+        'urlAuthorize' => 'https://www.facebook.com/dialog/oauth',
+        'urlAccessToken' => 'https://graph.facebook.com/oauth/access_token',
+        // Add requested attributes as fields
+        'urlResourceOwnerDetails' => 'https://graph.facebook.com/me?fields=id,name,first_name,last_name,email',
+        // Custom query parameters to add request email
+        'urlAuthorizeOptions' => [
+            // request email access
+            'req_perm' => 'email',
+        ],
+        // Prefix attributes so we can use the facebook2name
+        'attributePrefix' => 'facebook.',
+
+        // Improve log lines
+        'label' => 'facebook'
+    ];
+
     const GoogleOIDC = [
         'authoauth2:OAuth2',
         // *** Google Endpoints ***
@@ -22,6 +41,35 @@ class ConfigTemplate {
 
         // Improve log lines
         'label' => 'google'
+    ];
+
+    const LinkedIn = [
+        'authoauth2:OAuth2',
+        // *** LinkedIn Endpoints ***
+        'urlAuthorize' => 'https://www.linkedin.com/oauth/v2/authorization',
+        'urlAccessToken' => 'https://www.linkedin.com/oauth/v2/accessToken',
+        'urlResourceOwnerDetails' => 'https://api.linkedin.com/v1/people/~?format=json',
+        //scopes are the default ones configured for your application
+        'attributePrefix' => 'linkedin.',
+
+        // Improve log lines
+        'label' => 'linkedin'
+    ];
+
+    //https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc
+    //https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+    const MicrosoftOIDC = [
+        'authoauth2:OAuth2',
+        // *** Microsoft graph Endpoints ***
+        'urlAuthorize' => 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+        'urlAccessToken' => 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+        'urlResourceOwnerDetails' => 'https://graph.microsoft.com/oidc/userinfo',
+        'attributePrefix' => 'oidc.',
+        'scopes' => ['openid', 'email', 'profile'],
+        'scopeSeparator' => ' ',
+
+        // Improve log lines
+        'label' => 'microsoft'
     ];
 
     const YahooOIDC = [

--- a/lib/ConfigTemplate.php
+++ b/lib/ConfigTemplate.php
@@ -76,12 +76,13 @@ class ConfigTemplate {
     ];
 
     const MicrosoftGraphV1 = [
-        'authoauth2:OAuth2',
+        'authoauth2:MicrosoftHybridAuth',
         // *** Microsoft graph Endpoints ***
         'urlAuthorize' => 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
         'urlAccessToken' => 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
         'urlResourceOwnerDetails' => 'https://graph.microsoft.com/v1.0/me/',
         'attributePrefix' => 'microsoft.',
+        // graph v1 requires user.read
         'scopes' => ['openid', 'email', 'profile', 'user.read'],
         'scopeSeparator' => ' ',
 

--- a/lib/ConfigTemplate.php
+++ b/lib/ConfigTemplate.php
@@ -58,14 +58,31 @@ class ConfigTemplate {
 
     //https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc
     //https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+    // WARNING: The OIDC user resource endpoint only returns sub, which is a targeted id.
+    // You must decode the id token instead to determine user attributes. There you will
+    // find oid which is the ID you are probably expecting if you are moving from the live apis.
     const MicrosoftOIDC = [
         'authoauth2:OAuth2',
-        // *** Microsoft graph Endpoints ***
+        // *** Microsoft oidc Endpoints ***
         'urlAuthorize' => 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
         'urlAccessToken' => 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
         'urlResourceOwnerDetails' => 'https://graph.microsoft.com/oidc/userinfo',
         'attributePrefix' => 'oidc.',
         'scopes' => ['openid', 'email', 'profile'],
+        'scopeSeparator' => ' ',
+
+        // Improve log lines
+        'label' => 'microsoft'
+    ];
+
+    const MicrosoftGraphV1 = [
+        'authoauth2:OAuth2',
+        // *** Microsoft graph Endpoints ***
+        'urlAuthorize' => 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+        'urlAccessToken' => 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+        'urlResourceOwnerDetails' => 'https://graph.microsoft.com/v1.0/me/',
+        'attributePrefix' => 'microsoft.',
+        'scopes' => ['openid', 'email', 'profile', 'user.read'],
         'scopeSeparator' => ' ',
 
         // Improve log lines

--- a/tests/lib/Auth/Source/MicrosoftHybridAuthTest.php
+++ b/tests/lib/Auth/Source/MicrosoftHybridAuthTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: patrick
+ * Date: 10/17/18
+ * Time: 12:23 PM
+ */
+
+namespace Test\SimpleSAML\Auth\Source;
+
+use AspectMock\Test as test;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
+use SimpleSAML\Module\authoauth2\Auth\Source\MicrosoftHybridAuth;
+use Test\SimpleSAML\MockOAuth2Provider;
+
+
+class MicrosoftHybridAuthTest extends \PHPUnit_Framework_TestCase
+{
+
+    public static function setUpBeforeClass()
+    {
+        putenv('SIMPLESAMLPHP_CONFIG_DIR=' . dirname(dirname(dirname(__DIR__))) . '/config');
+    }
+
+    protected function tearDown()
+    {
+        test::clean(); // remove all registered test doubles
+    }
+
+    /**
+     * @dataProvider combineOidcAndGraphProfileProvider
+     * @param string $idToken The id_token response from the server
+     * @param array $expectedAttributes The expected attributes
+     */
+    public function testCombineOidcAndGraphProfile($idToken, array $expectedAttributes)
+    {
+        // given: A mock Oauth2 provider
+        $code = 'theCode';
+        $info = ['AuthId' => 'oauth2'];
+        $config = [
+            'template' => 'MicrosoftGraphV1',
+            'providerClass' => MockOAuth2Provider::class,
+        ];
+        $state = [\SimpleSAML_Auth_State::ID => 'stateId'];
+
+        /**
+         * @var $mock AbstractProvider|\PHPUnit_Framework_MockObject_MockObject
+         */
+        $mock = $this->getMockBuilder(AbstractProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $token = new AccessToken(['access_token' => 'stubToken', 'id_token' => $idToken]);
+        $mock->method('getAccessToken')
+            ->with('authorization_code', ['code' => $code])
+            ->willReturn($token);
+
+        // graph api seems to return null for email
+        $attributes = ['id' => 'a76d6a7a097c1e9d', 'mail' => null];
+        $user = new GenericResourceOwner($attributes, 'userId');
+
+        $mock->method('getResourceOwner')
+            ->with($token)
+            ->willReturn($user);
+
+        MockOAuth2Provider::setDelegate($mock);
+
+        // when: turning a code into a token and then into a resource owner attributes
+        $authOAuth2 = new MicrosoftHybridAuth($info, $config);
+        $authOAuth2->finalStep($state, $code);
+
+        // then: The attributes should be returned based on the getResourceOwner call
+        $this->assertEquals($expectedAttributes, $state['Attributes']);
+
+    }
+
+    public function combineOidcAndGraphProfileProvider() {
+        $expectedGraphAttributes = ['microsoft.id' => ['a76d6a7a097c1e9d']];
+        // A Graph Id token. note: only the payload is valid. Header and signature are not
+        $validIdToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjFMVE16YWtpaGlSbGFfOHoyQkVKVlhlV01xbyJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vOTE4ODA0MGQtNmM2Ny00YzViLWIxMTItMzZhMzA0YjY2ZGFkL3YyLjAiLCJzdWIiOiJBQUFBQUFBQUFBQUFBQUFBQUFBQUFORHBFcUNHa3lPVVFDTXpHOHRGYUUiLCJhdWQiOiI5ZTdkZTIyZS0zYTE3LTQ0ZmQtODdjNy1jNmVjZWIxYmVlMGUiLCJleHAiOjE1Mzk5NjUwNDUsImlhdCI6MTUzOTg3ODM0NSwibmJmIjoxNTM5ODc4MzQ1LCJuYW1lIjoiU3RldmUgU3RyYXR1cyIsInByZWZlcnJlZF91c2VybmFtZSI6InN0ZXZlLnN0cmF0dXNAb3V0bG9vay5jb20iLCJvaWQiOiIwMDAwMDAwMC0wMDAwLTAwMDAtYTc2ZDZhN2EwOTdjMWU5ZCIsImVtYWlsIjoic3RldmUuc3RyYXR1c0BvdXRsb29rLmNvbSIsInRpZCI6IjkxODgwNDBkLTZjNjctNGM1Yi1iMTEyMzZhMzA0YjY2ZGFkIiwiYWlvIjoiRGI1YmRMSHBaSkdla0h3czlxaHlkUkFHSGR1cSFvUDdpS1cxYzFFQkd2dWhDWnZXS2luS0FoVnFZV3NtYSEwT3ZiRTFmV1J2TUF3NHFLUVBud3N6akQwKkd2N1RsbFpOY2FxcDQ0eTM0ZyJ9.SjNeBS11Qa2eXKLhxSApShFMLQ9nDjTXT27JZm3cctM';
+
+        return [
+            // jwt, expected attributes
+          ['invalidJwt', $expectedGraphAttributes],
+          ['', $expectedGraphAttributes],
+          [null, $expectedGraphAttributes],
+          ['blah.abc.egd', $expectedGraphAttributes],
+            [$validIdToken, ['microsoft.name' => ['Steve Stratus'], 'microsoft.mail' => ['steve.stratus@outlook.com'], 'microsoft.id' => ['a76d6a7a097c1e9d']] ]
+
+        ];
+    }
+}


### PR DESCRIPTION
Microsoft Graph api needs its own authsource since some attributes (like email) are only available in the id_token while other attributes (like first name) need to come from the graph api call.