### PR TITLE
Add support for Bitbucket OAuth clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Almost all OAuth2/OIDC providers will require you to register a redirect URI. Us
 
 ## Provider specific Tips
 
+ * [Bitbucket](/docs/BITBUCKET.md)
  * [Google](/docs/GOOGLE.md)
  * [LinkedIn](/docs/LINKEDIN.md)
  * [Microsoft](/docs/MICROSOFT.md)

--- a/attributemap/bitbucket2name.php
+++ b/attributemap/bitbucket2name.php
@@ -1,0 +1,7 @@
+<?php
+$attributemap = array(
+
+    'bitbucket.display_name' => 'displayName',
+    'bitbucket.account_id' => 'uid',
+    'bitbucket.email' => 'mail',
+);

--- a/docs/BITBUCKET.md
+++ b/docs/BITBUCKET.md
@@ -1,0 +1,43 @@
+**Table of Contents**
+
+- [Bitbucket as authsource](#bitbucket-as-authsource)
+- [Usage](#usage)
+- [Creating Bitbucket OAuth Client](#creating-bitbucket-oauth-client)
+
+# Bitbucket as authsource
+
+Bitbucket recommends using OAuth2 and their apis. Bitbucket apis return data in a
+json format and require additional API calls to get an email address. You need to use the
+`authoauth2:BitbucketAuth` authsource since Bitbucket doesn't conform
+the expected OIDC/OAuth pattern.
+
+# Usage
+
+```php
+   'bitbucket' => [
+        'authoauth2:BitbucketAuth',
+        'clientId' => $apiKey,
+        'clientSecret' =>  $apiSecret,
+        // Adjust the scopes: default is to request email and account
+        //'scopes' => ['account', 'email'],
+    ],
+```
+
+# Creating Bitbucket OAuth Client
+
+Bitbucket provides [documentation](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html). Follow the section related to 'Create a consumer' to create an OAuth consumer.
+You will need to add the correct redirect URI to your OAuth2 client in the Bitbucket console. Use a url of the form below, and set hostname, SSP_PATH and optionally port to the correct values.
+
+https://hostname/SSP_PATH/module.php/authoauth2/linkback.php
+
+You will then need to change your `authsource` configuration to match the example usage above.
+
+On your idp side you may need to use `bitbucket2name` attribute mapping from this module.
+
+```php
+        // Convert bitbucket names to ldap friendly names
+        10 => array(
+            'class' => 'core:AttributeMap',
+            'authoauth2:bitbucket2name'
+        ),
+```

--- a/lib/Auth/Source/BitbucketAuth.php
+++ b/lib/Auth/Source/BitbucketAuth.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\Auth\Source;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Token\AccessToken;
+use SimpleSAML\Logger;
+use SimpleSAML\Module\authoauth2\ConfigTemplate;
+
+/**
+ * Bitbucket's api requires a 2nd call to determine email address.
+ *
+ * @author nikosev<nikos.ev@hotmail.com>
+ * @package SimpleSAMLphp
+ */
+class BitbucketAuth extends OAuth2
+{
+
+    public function __construct(array $info, array $config)
+    {
+        // Set some defaults
+        if (!array_key_exists('template', $config)) {
+            $config['template'] = 'Bitbucket';
+        }
+        parent::__construct($info, $config);
+    }
+
+
+    /**
+     * Query Bitbucket's email endpoint if needed.
+     * Public for testing
+     * @param AccessToken $accessToken
+     * @param AbstractProvider $provider
+     * @param array $state
+     */
+    public function postFinalStep(AccessToken $accessToken, AbstractProvider $provider, &$state)
+    {
+        if (!in_array('email', $this->config->getArray('scopes'))) {
+            // We didn't request email scope originally
+            return;
+        }
+        $emailUrl = $this->getConfig()->getString('urlResourceOwnerEmail');
+        $request = $provider->getAuthenticatedRequest('GET', $emailUrl, $accessToken);
+        try {
+            $response = $this->retry(
+                function () use ($provider, $request) {
+                    return $provider->getParsedResponse($request);
+                },
+                $this->config->getInteger('retryOnError', 1)
+            );
+        } catch (\Exception $e) {
+            // not getting email shouldn't fail the authentication
+            Logger::error(
+                'BitbucketAuth: ' . $this->getLabel() . ' exception email query response ' . $e->getMessage()
+            );
+            return;
+        }
+
+        // if the user has multiple email addresses, pick the primary one
+        if (is_array($response) && isset($response["size"])) {
+            for ($i = 0; $i < $response["size"]; $i++) {
+                if ($response["values"][$i]["is_primary"] == "true" && $response["values"][$i]["type"] == "email") {
+                    $prefix = $this->getAttributePrefix();
+                    $state['Attributes'][$prefix . 'email'] = [$response["values"][$i]["email"]];
+                }
+            }
+        } else {
+            Logger::error(
+                'BitbucketAuth: ' . $this->getLabel() . ' invalid email query response ' . var_export($response, true)
+            );
+        }
+    }
+}

--- a/lib/ConfigTemplate.php
+++ b/lib/ConfigTemplate.php
@@ -149,5 +149,20 @@ class ConfigTemplate
         // uid attribute from token response needs to be included in user details call
         'tokenFieldsToUserDetailsUrl' => ['uid' => 'uid', 'access_token' => 'access_token'],
     ];
+
+    const Bitbucket = [
+        'authoauth2:BitbucketAuth',
+        // *** Bitbucket Endpoints ***
+        'urlAuthorize' => 'https://bitbucket.org/site/oauth2/authorize',
+        'urlAccessToken' => 'https://bitbucket.org/site/oauth2/access_token',
+        'urlResourceOwnerDetails' => 'https://api.bitbucket.org/2.0/user',
+        'urlResourceOwnerEmail' => 'https://api.bitbucket.org/2.0/user/emails',
+        //scopes are the default ones configured for your application
+        'attributePrefix' => 'bitbucket.',
+        'scopes' => ['account', 'email'],
+        'scopeSeparator' => ' ',
+        // Improve log lines
+        'label' => 'bitbucket'
+    ];
 }
 // phpcs:enable


### PR DESCRIPTION
This PR extends OAuth2 class to support Bitbucket OAuth clients.
Butbucket API requires a second call in order to obtain the email address of the user.