### PR TITLE
Create a state id without restart url

### DIFF
--- a/lib/Auth/Source/OAuth2.php
+++ b/lib/Auth/Source/OAuth2.php
@@ -104,7 +104,7 @@ class OAuth2 extends \SimpleSAML\Auth\Source
         // We are going to need the authId in order to retrieve this authentication source later, in the callback
         $state[self::AUTHID] = $this->getAuthId();
 
-        $stateID = \SimpleSAML\Auth\State::saveState($state, self::STAGE_INIT);
+        $stateID = \SimpleSAML\Auth\State::saveState($state, self::STAGE_INIT, true);
 
         $providerLabel = $this->getLabel();
         Logger::debug("authoauth2: $providerLabel saved state with stateID=$stateID");


### PR DESCRIPTION
The restart url only makes sense for saml idps, and it will
potentially leak quite a bit of information that was encoded in the
url to the OP. Also the shorted state parameter makes for nice urls.