### PR TITLE
OpenID Connect: Fix non-canonical URL used for discovery endpoint

### DIFF
--- a/lib/Providers/OpenIDConnectProvider.php
+++ b/lib/Providers/OpenIDConnectProvider.php
@@ -110,7 +110,7 @@ class OpenIDConnectProvider extends AbstractProvider
             return $this->openIdConfiguration;
         }
 
-        $config = $this->getParsedResponse($this->getRequest('GET', $this->issuer . self::CONFIGURATION_PATH));
+        $config = $this->getParsedResponse($this->getRequest('GET', rtrim($this->issuer, '/') . self::CONFIGURATION_PATH));
         $requiredEndPoints = [ "authorization_endpoint", "token_endpoint", "jwks_uri", "issuer", "userinfo_endpoint" ];
         foreach ($requiredEndPoints as $key) {
             if (!array_key_exists($key, $config)) {


### PR DESCRIPTION
The OpenID Connect specification allows the Issuer to contain a trailing slash. E.g.:

  https://example.com/oidc/

This code would form the following URL for the discovery endpoint:

  https://example.com/oidc//.well-known/openid-configuration

Some servers may reject this URL because it contains two slashes.

The OpenID Connect specification requires a trailing slash from the Issuer to be removed before concatenating the well-known path to it:

> If the Issuer value contains a path component, any terminating `/` MUST be removed before appending `/.well-known/openid-configuration`.
(https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest)

This patch updates the code to remove any trailing slashes from Issuer before concatenating.