### PR TITLE
Handle aud being an array

### DIFF
--- a/lib/Providers/OpenIDConnectProvider.php
+++ b/lib/Providers/OpenIDConnectProvider.php
@@ -92,7 +92,9 @@ class OpenIDConnectProvider extends AbstractProvider
         try {
             $keys = $this->getSigningKeys();
             $claims = JWT\JWT::decode($id_token, $keys, ['RS256']);
-            if ($claims->aud !== $this->clientId) {
+            $aud = is_array($claims->aud) ? $claims->aud : [$claims->aud];
+
+            if (!in_array($this->clientId, $aud)) {
                 throw new IdentityProviderException("ID token has incorrect audience", 0, $claims->aud);
             }
             if ($claims->iss !== $this->issuer) {


### PR DESCRIPTION
Previously only aud as a single string was supported.
It can also be an array of one or multiple values.

See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3