### PR TITLE
Add support for PKCE and AuthProc filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=7.4 || ^8.0",
     "simplesamlphp/composer-module-installer": "^1.1",
-    "league/oauth2-client": "^2.6",
+    "league/oauth2-client": "^2.7",
     "simplesamlphp/simplesamlphp": "^v2.0.0",
     "firebase/php-jwt": "^5.5|^6",
     "kevinrob/guzzle-cache-middleware": "^4.1.1",

--- a/docs/AUTHPROC.md
+++ b/docs/AUTHPROC.md
@@ -1,0 +1,63 @@
+# AUTHPROC support
+
+In SimpleSAMLphp (SSP) there is an API where you can do something after authentication is complete.
+Authentication processing filters (AuthProc filters) postprocess authentication information received from the
+authentication sources.
+
+However, if an authsource is not a regular SAML SP (or IdP), the authproc filters are not executed.
+
+The `authoauth2` module provides a way to postprocess the authentication information
+similar to regular SAML SPs. The module provides its own 'authproc.oauth2' configuration option for that purpose.
+Its implementation is influenced by the SSP OIDC module.
+
+The primary use case focuses on attribute manipulation following authentication to ensure that the attributes
+of an OAuth 2.0/OpenID Connect (OIDC) login mirror those of a regular SAML Service Provider (SP).
+This consistency allows users to log in using different authentication sources while maintaining
+uniform attributes across the board.
+
+## Limitations
+
+Currently, the 'authoauth2' module only supports basic filter use cases like attribute handling, logging or similar.
+Filters that add additional authentication steps, e.g. by showing a page to the user, are not supported.
+
+## Usage
+
+Add the 'authproc.oauth2' config option in the same way as described in the
+[Auth Proc documentation](https://simplesamlphp.org/docs/stable/simplesamlphp-authproc.html).
+In addition you need to activate authproc filtering by setting the `authProcStrategyClass`.
+The default implementation would be `authoauth2:AuthProcStrategy`
+
+## Example configuration
+
+Below is an example demonstrating how to configure the `authoauth2` module for PKCE with the `S256` method and session storage strategy:
+
+```php
+// config/authsources.php
+
+$config = [
+    'my-oidc-auth-source' => [
+        'authoauth2:OpenIDConnect',
+
+        'issuer' => 'https://my-issuer',
+        'clientId' => 'client-id',
+        'clientSecret' => 'client-secret',
+        
+        // activate PKCE with the S256 method and session storage strategy
+        'pkceMethod' => 'S256',
+        'pkceStrategyClass' => 'authoauth2:PkceSessionStrategy',
+        
+        'authProcStrategyClass' => 'authoauth2:AuthProcStrategy',
+        'authproc.oauth2' => [
+            10 => [
+                'class' => 'core:AttributeAdd',
+                'groups' => ['user', 'members'],
+            ],
+        ]
+    ]
+];
+```
+
+## Links
+
+- See https://simplesamlphp.org/docs/stable/simplesamlphp-authproc.html for the regular SSP authproc documentation.
+- authproc.oidc implementation: https://github.com/simplesamlphp/simplesamlphp-module-oidc#auth-proc-filters

--- a/docs/PKCE.md
+++ b/docs/PKCE.md
@@ -1,0 +1,41 @@
+# PKCE support
+
+PKCE (Proof Key for Code Exchange) is an extension to the OAuth2 protocol that is used to secure the authorization code flow against CSRF (cross site request forgery) and code injection attacks.
+PKCE is recommended in almost all OAuth use cases. Some servers or operators require the clients to use PKCE.
+
+## Usage
+
+Activating PKCE with the SSP authoauth2 module involves the subsequent steps:
+- enable PKCE by setting the `pkceMethod` configuration key to a valid value (`S256` or `plain` (not recommended))
+  - you could use the constants from the underlying `league/oauth2-client` library:
+    - `League\OAuth2\Client\Provider\AbstractProvider::PKCE_METHOD_S256` or
+    - `League\OAuth2\Client\Provider\AbstractProvider::PKCE_METHOD_PLAIN`
+- define a PkceStrategy class, that is responsible for storing and retrieving the proof key. The default implementation stores the proof key in the session. You can use the `PkceSessionStrategy` class for this approach.
+
+### Example configuration
+
+Below is an example demonstrating how to configure the `authoauth2` module for PKCE with the `S256` method and session storage strategy:
+
+```php
+// config/authsources.php
+
+$config = [
+    'my-oidc-auth-source' => [
+        'authoauth2:OpenIDConnect',
+
+        'issuer' => 'https://my-issuer',
+        'clientId' => 'client-id',
+        'clientSecret' => 'client-secret',
+        
+        // activate PKCE with the S256 method and session storage strategy
+        'pkceMethod' => 'S256',
+        'pkceStrategyClass' => 'authoauth2:PkceSessionStrategy',
+    ]
+];
+```
+
+## Links
+
+- See https://github.com/thephpleague/oauth2-client/blob/master/docs/usage.md#authorization-code-grant-with-pkce
+  for implementation notes of the underlying library.
+- RFC 7636 for PKCE: https://datatracker.ietf.org/doc/html/rfc7636

--- a/src/Auth/Source/BitbucketAuth.php
+++ b/src/Auth/Source/BitbucketAuth.php
@@ -70,5 +70,7 @@ class BitbucketAuth extends OAuth2
                 'BitbucketAuth: ' . $this->getLabel() . ' invalid email query response ' . var_export($response, true)
             );
         }
+
+        parent::postFinalStep($accessToken, $provider, $state);
     }
 }

--- a/src/Auth/Source/LinkedInV2Auth.php
+++ b/src/Auth/Source/LinkedInV2Auth.php
@@ -140,5 +140,7 @@ class LinkedInV2Auth extends OAuth2
                 'linkedInv2Auth: ' . $this->getLabel() . ' invalid email query response ' . var_export($response, true)
             );
         }
+
+        parent::postFinalStep($accessToken, $provider, $state);
     }
 }

--- a/src/Auth/Source/MicrosoftHybridAuth.php
+++ b/src/Auth/Source/MicrosoftHybridAuth.php
@@ -46,5 +46,7 @@ class MicrosoftHybridAuth extends OAuth2
         if (array_key_exists('name', $idTokenData)) {
             $state['Attributes'][$prefix . 'name'] = [$idTokenData['name']];
         }
+
+        parent::postFinalStep($accessToken, $provider, $state);
     }
 }

--- a/src/Auth/Source/OpenIDConnect.php
+++ b/src/Auth/Source/OpenIDConnect.php
@@ -111,6 +111,8 @@ class OpenIDConnect extends OAuth2
         $state['id_token'] = $id_token;
         $state['PersistentAuthData'][] = 'id_token';
         $state['LogoutState'] = ['id_token' => $id_token];
+
+        parent::postFinalStep($accessToken, $provider, $state);
     }
 
     /**

--- a/src/Strategy/AbstractStrategy.php
+++ b/src/Strategy/AbstractStrategy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\Strategy;
+
+use SimpleSAML\Module\authoauth2\Strategy\StrategyInterface;
+
+class AbstractStrategy implements StrategyInterface
+{
+    protected array $config = [];
+    public function initWithConfig(array $config): void
+    {
+        $this->config = $config;
+    }
+}

--- a/src/Strategy/AuthProcStrategy.php
+++ b/src/Strategy/AuthProcStrategy.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\Strategy;
+
+use Exception;
+use InvalidArgumentException;
+use SimpleSAML\Auth\ProcessingFilter;
+use SimpleSAML\Module\authoauth2\locators\SspProcessingFilterResolver;
+use SimpleSAML\Module\authoauth2\locators\ProcessingFilterResolverInterface;
+
+class AuthProcStrategy extends AbstractStrategy implements AuthProcStrategyInterface
+{
+    private const AUTH_PROC_KEY = 'authproc.oauth2';
+
+    private ProcessingFilterResolverInterface $filterResolver;
+
+    /**
+     * @var array<ProcessingFilter> Filters to be applied to current state.
+     */
+    private array $filters = [];
+
+    public function __construct(?ProcessingFilterResolverInterface $filterResolver = null)
+    {
+        $this->filterResolver = $filterResolver ?: new SspProcessingFilterResolver();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function initWithConfig(array $config): void
+    {
+        if (isset($config[self::AUTH_PROC_KEY]) && is_array($config[self::AUTH_PROC_KEY])) {
+            $this->filters = $this->parseFilterList($config[self::AUTH_PROC_KEY]);
+        }
+    }
+
+    public function processState(array &$state): array
+    {
+        foreach ($this->filters as $filter) {
+            $filter->process($state);
+        }
+
+        return $state;
+    }
+
+    /**
+     * Parse an array of authentication processing filters.
+     * @see \SimpleSAML\Auth\ProcessingChain::parseFilterList for original implementation
+     *
+     * @param array<mixed|string|array{class: string}> $filterSrc Array with filter configuration.
+     *
+     * @return ProcessingFilter[]  Array of ProcessingFilter objects.
+     *
+     * @throws Exception
+     */
+    private function parseFilterList(array $filterSrc): array
+    {
+        /** @var ProcessingFilter[] $parsedFilters */
+        $parsedFilters = [];
+
+        foreach ($filterSrc as $priority => $filterConfig) {
+            if (is_string($filterConfig)) {
+                $filterConfig = ['class' => $filterConfig];
+            }
+
+            /** @psalm-suppress DocblockTypeContradiction */
+            if (!is_array($filterConfig)) {
+                throw new InvalidArgumentException('Invalid authentication processing filter configuration: ' .
+                    'One of the filters was not a string or an array.');
+            }
+
+            if (!array_key_exists('class', $filterConfig)) {
+                throw new InvalidArgumentException('Authentication processing filter without name given.');
+            }
+            $sspClassString = (string)$filterConfig['class'];
+            unset($filterConfig['class']);
+            $filterConfig['%priority'] = $priority;
+
+            $parsedFilters[(int)$priority] = $this->filterResolver->instantiate($sspClassString, $filterConfig);
+        }
+
+        // sort the filters by priority
+        ksort($parsedFilters);
+
+        return $parsedFilters;
+    }
+}

--- a/src/Strategy/AuthProcStrategyInterface.php
+++ b/src/Strategy/AuthProcStrategyInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\Strategy;
+
+interface AuthProcStrategyInterface extends StrategyInterface
+{
+    public function processState(array &$state): array;
+}

--- a/src/Strategy/PkceSessionStrategy.php
+++ b/src/Strategy/PkceSessionStrategy.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\Strategy;
+
+use Exception;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use SimpleSAML\Session;
+
+class PkceSessionStrategy extends AbstractStrategy implements PkceStrategyInterface
+{
+    public const SESSION_NAMESPACE = 'authoauth2_pkce';
+    public const PKCE_SESSION_KEY = 'pkceCode';
+
+    private ?Session $session;
+
+    public function __construct(?Session $session = null)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function saveCodeChallengeFromProvider(AbstractProvider $provider, array &$state): void
+    {
+        $this->getSession()->setData(self::SESSION_NAMESPACE, self::PKCE_SESSION_KEY, $provider->getPkceCode());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function loadCodeChallengeIntoProvider(AbstractProvider $provider, array &$state): void
+    {
+        $code = (string)$this->getSession()->getData(self::SESSION_NAMESPACE, self::PKCE_SESSION_KEY);
+        if ($code) {
+            $provider->setPkceCode($code);
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getSession(): Session
+    {
+        return $this->session ?: Session::getSessionFromRequest();
+    }
+}

--- a/src/Strategy/PkceStrategyInterface.php
+++ b/src/Strategy/PkceStrategyInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\Strategy;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+
+interface PkceStrategyInterface extends StrategyInterface
+{
+    /**
+     * support saving the providers PKCE code in the session for later verification.
+     *
+     * Note: the state is not the same as in `loadCodeChallengeIntoProvider`
+     */
+    public function saveCodeChallengeFromProvider(AbstractProvider $provider, array &$state): void;
+
+    /**
+     * support retrieving the PKCE code from tne session for verification.
+     *
+     * Note: the state is not the same as in `saveCodeChallengeFromProvider`
+     */
+    public function loadCodeChallengeIntoProvider(AbstractProvider $provider, array &$state): void;
+}

--- a/src/Strategy/StrategyInterface.php
+++ b/src/Strategy/StrategyInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\Strategy;
+
+interface StrategyInterface
+{
+    public function initWithConfig(array $config): void;
+}

--- a/src/locators/ClassResolverInterface.php
+++ b/src/locators/ClassResolverInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\locators;
+
+interface ClassResolverInterface
+{
+    /**
+     * Resolve module class.
+     *
+     * This function takes a string on the form "<module>:<class>" and converts it to a class
+     * name. It can also check that the given class is a subclass of a specific class. The
+     * resolved classname will be "\SimleSAML\Module\<module>\<$type>\<class>.
+     *
+     * It is also possible to specify a full classname instead of <module>:<class>.
+     *
+     * An exception will be thrown if the class can't be resolved.
+     *
+     * @param string      $id The string we should resolve.
+     * @param string      $type The type of the class.
+     * @param string|null $subclass The class should be a subclass of this class. Optional.
+     *
+     * @return string The classname.
+     *
+     * @throws \Exception If the class cannot be resolved.
+     */
+    public function resolveClass(string $id, string $type, ?string $subclass = null): string;
+}

--- a/src/locators/ProcessingFilterResolverInterface.php
+++ b/src/locators/ProcessingFilterResolverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\locators;
+
+use SimpleSAML\Auth\ProcessingFilter;
+
+interface ProcessingFilterResolverInterface
+{
+    public function instantiate(string $sspClassString, array $filterConfig): ProcessingFilter;
+}

--- a/src/locators/SspProcessingFilterResolver.php
+++ b/src/locators/SspProcessingFilterResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SimpleSAML\Module\authoauth2\locators;
+
+use SimpleSAML\Auth\ProcessingFilter;
+use SimpleSAML\Module;
+
+class SspProcessingFilterResolver implements ProcessingFilterResolverInterface
+{
+    public function instantiate(string $sspClassString, array $filterConfig): ProcessingFilter
+    {
+        /** @var class-string<ProcessingFilter> $className */
+        $className = Module::resolveClass(
+            $sspClassString,
+            'Auth\Process',
+            ProcessingFilter::class
+        );
+
+        /** @psalm-suppress UnsafeInstantiation */
+        return new $className($filterConfig, null);
+    }
+}

--- a/tests/lib/Providers/OpenIDConnectProviderTest.php
+++ b/tests/lib/Providers/OpenIDConnectProviderTest.php
@@ -5,6 +5,7 @@ namespace Test\SimpleSAML\Providers;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Module\authoauth2\Auth\Source\OAuth2;
 use SimpleSAML\Module\authoauth2\Providers\OpenIDConnectProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Test\SimpleSAML\MockOpenIDConnectProvider;
@@ -94,6 +95,67 @@ class OpenIDConnectProviderTest extends TestCase
         $this->assertEquals(
             'https://otherhost.example.com/path/path2/.well-known/openid-configuration',
             $provider->getDiscoveryUrl()
+        );
+    }
+
+    public function testInitializingWithoutPkceMethod(): void
+    {
+        $provider = new OpenIDConnectProvider(
+            ['issuer' => 'https://accounts.example.com']
+        );
+
+        // assert the protected provider member is null
+        $reflector = new \ReflectionClass(OpenIDConnectProvider::class);
+        $method = $reflector->getMethod('getPkceMethod');
+        $method->setAccessible(true);
+
+        $this->assertNull($method->invoke($provider));
+    }
+
+    public function testInitializingWithPkceMethodSetToS256(): void
+    {
+        $provider = new OpenIDConnectProvider(
+            [
+                'issuer' => 'https://accounts.example.com',
+                'pkceMethod' => 'S256'
+            ]
+        );
+
+        // assert the protected provider member is null
+        $reflector = new \ReflectionClass(OpenIDConnectProvider::class);
+        $method = $reflector->getMethod('getPkceMethod');
+        $method->setAccessible(true);
+
+        $this->assertEquals('S256', $method->invoke($provider));
+    }
+
+    public function testInitializingWithPkceMethodSetToPlain(): void
+    {
+        $provider = new OpenIDConnectProvider(
+            [
+                'issuer' => 'https://accounts.example.com',
+                'pkceMethod' => 'plain'
+            ]
+        );
+
+        // assert the protected provider member is null
+        $reflector = new \ReflectionClass(OpenIDConnectProvider::class);
+        $method = $reflector->getMethod('getPkceMethod');
+        $method->setAccessible(true);
+
+        $this->assertEquals('plain', $method->invoke($provider));
+    }
+
+    public function testInitializingWithInvalidPkceMethodFails(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported pkceMethod: invalid');
+
+        new OpenIDConnectProvider(
+            [
+                'issuer' => 'https://accounts.example.com',
+                'pkceMethod' => 'invalid'
+            ]
         );
     }
 }

--- a/tests/lib/Strategy/AuthProcStrategyTest.php
+++ b/tests/lib/Strategy/AuthProcStrategyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Test\SimpleSAML\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Auth\ProcessingFilter;
+use SimpleSAML\Module\authoauth2\locators\ProcessingFilterResolverInterface;
+use SimpleSAML\Module\authoauth2\Strategy\AuthProcStrategy;
+
+class AuthProcStrategyTest extends TestCase
+{
+    /**
+     * test that the strategy can be instantiated and that the filters are processed in the correct order.
+     */
+    public function testProcessStateWithSomeFilters(): void
+    {
+        // Create a mock filter that expects to process state once
+        $mockFilterA = $this->createMock(ProcessingFilter::class);
+        $mockFilterA->expects($this->once())
+            ->method('process')
+            ->willReturnCallback(
+                function (array &$state) {
+                    $state['processedA'] = true;
+                    $state['lastProcess'] = 'A';
+                }
+            );
+        $mockFilterB = $this->createMock(ProcessingFilter::class);
+        $mockFilterB->expects($this->once())
+            ->method('process')
+            ->willReturnCallback(
+                function (array &$state) {
+                    $state['processedB'] = true;
+                    $state['lastProcess'] = 'B';
+                }
+            );
+
+        // Mock the filter resolver to return our mock filter when instantiated
+        $mockFilterResolver = $this->createMock(ProcessingFilterResolverInterface::class);
+        $mockFilterResolver->expects($this->exactly(2))
+            ->method('instantiate')
+            ->willReturn($mockFilterA, $mockFilterB);
+
+        // Instantiate AuthProcStrategy with our mock filter resolver
+        $authProcStrategy = new AuthProcStrategy($mockFilterResolver);
+
+        // Assume valid config
+        $config = [
+            'authproc.oauth2' => [
+                20 => ['class' => 'Some\Filter\Class'],
+                10 => ['class' => 'Some\Filter\Class'],
+            ],
+        ];
+
+        $authProcStrategy->initWithConfig($config);
+
+        $state = [];
+        $authProcStrategy->processState($state);
+
+        // Assert that state was processed by our mock filters
+        $this->assertTrue($state['processedA']);
+        $this->assertTrue($state['processedB']);
+        // Test, that the filters ran in a certain order
+        $this->assertEquals('A', $state['lastProcess']);
+    }
+}

--- a/tests/lib/Strategy/PkceSessionStrategyTest.php
+++ b/tests/lib/Strategy/PkceSessionStrategyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Test\SimpleSAML\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use SimpleSAML\Module\authoauth2\Strategy\PkceSessionStrategy;
+use SimpleSAML\Session;
+
+class PkceSessionStrategyTest extends TestCase
+{
+    public function testSaveCodeChallengeFromProvider(): void
+    {
+        $codeChallenge = 'some_code_challenge';
+
+        $providerMock = $this->createMock(AbstractProvider::class);
+        $providerMock->expects($this->once())
+            ->method('getPkceCode')
+            ->willReturn($codeChallenge);
+
+        $sessionMock = $this->createMock(Session::class);
+        $sessionMock->expects($this->once())
+            ->method('setData')
+            ->with(
+                PkceSessionStrategy::SESSION_NAMESPACE,
+                PkceSessionStrategy::PKCE_SESSION_KEY,
+                $codeChallenge
+            );
+
+        $strategy = new PkceSessionStrategy($sessionMock);
+        $state = [];
+        $strategy->saveCodeChallengeFromProvider($providerMock, $state);
+    }
+
+    public function testLoadCodeChallengeIntoProvider(): void
+    {
+        $codeChallenge = 'some_code_challenge';
+
+        $providerMock = $this->createMock(AbstractProvider::class);
+        $providerMock->expects($this->once())
+            ->method('setPkceCode')
+            ->with($codeChallenge);
+
+        $sessionMock = $this->createMock(Session::class);
+        $sessionMock->expects($this->once())
+            ->method('getData')
+            ->with(PkceSessionStrategy::SESSION_NAMESPACE, PkceSessionStrategy::PKCE_SESSION_KEY)
+            ->willReturn($codeChallenge);
+
+        $strategy = new PkceSessionStrategy($sessionMock);
+        $state = [];
+        $strategy->loadCodeChallengeIntoProvider($providerMock, $state);
+    }
+
+    public function testLoadCodeChallengeIntoProviderNoCode(): void
+    {
+        $providerMock = $this->createMock(AbstractProvider::class);
+        $providerMock->expects($this->never())  // Ensure that setPkceCode() is not called
+        ->method('setPkceCode');
+
+        $sessionMock = $this->createMock(Session::class);
+        $sessionMock->expects($this->once())
+            ->method('getData')
+            ->with(PkceSessionStrategy::SESSION_NAMESPACE, PkceSessionStrategy::PKCE_SESSION_KEY)
+            ->willReturn(null);
+
+        $strategy = new PkceSessionStrategy($sessionMock);
+        $state = [];
+        $strategy->loadCodeChallengeIntoProvider($providerMock, $state);
+    }
+}


### PR DESCRIPTION
Added support for PKCE and AuthProc filters.

Reasons:
- PKCE is mandatory with some providers.
- AuthProc filters helps me to normalize the attributes between different SPs.

PKCE was implemented via the underlying library. For that I had to increase the minimum version for
`league/oauth2-client` to 2.7. I think this should be fine, as there seems not to be any dependency
differences between 2.6 and 2.7.

AuthProc filters were implemented in a similar way as the OIDC module is doing it. So it is separated
from the regular filters and only basic operations are supported (e.g. attribute modification).

I tried to be as less invasive as possible, so the features both needs a defined strategy class in the config
to get activated.

* [x] Tests added for this feature
* [x] Documentation added for this feature
* [x] Tests pass
* [x] `composer run validate` passes
