### PR TITLE
feat: support PKCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ docker run --name ssp-oauth2-dev \
   -e SSP_ENABLED_MODULES="authoauth2" \
   --mount type=bind,source="$(pwd)/docker/config/authsources.php",target=/var/simplesamlphp/config/authsources.php,readonly \
   --mount type=bind,source="$(pwd)/docker/config/config-override.php",target=/var/simplesamlphp/config/config-override.php,readonly \
-  -p 443:443 cirrusid/simplesamlphp:v2.0.0
+  -p 443:443 cirrusid/simplesamlphp:v2.0.7
 ```
 
 and visit (which resolves to localhost, and the docker container) the [test authsource page](https://oauth2-validation.local.stack-dev.cirrusidentity.com/simplesaml/module.php/admin/test)

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=7.4 || ^8.0",
     "simplesamlphp/composer-module-installer": "^1.1",
-    "league/oauth2-client": "^2.6",
+    "league/oauth2-client": "^2.7",
     "simplesamlphp/simplesamlphp": "^v2.0.0",
     "firebase/php-jwt": "^5.5|^6",
     "kevinrob/guzzle-cache-middleware": "^4.1.1",

--- a/docker/config/authsources.php
+++ b/docker/config/authsources.php
@@ -57,6 +57,18 @@ $config = array(
         'clientSecret' => 'GXc8Q~mgI7kTBllrvpBthUEioeARdjrRYORSyda4',
     ],
 
+    'microsoftOIDCPkceSource' => [
+        'authoauth2:OpenIDConnect',
+        'issuer' => 'https://sts.windows.net/{tenantid}/',
+        // When using the 'common' discovery endpoint it allows any Azure user to authenticate, however
+        // the token issuer is tenant specific and will not match what is in the common discovery document.
+        'validateIssuer' => false,  // issuer is just used to confirm correct discovery endpoint loaded
+        'discoveryUrl' => 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
+        'clientId' => 'f579dc6e-58f5-41a8-8bbf-96d54eacfe8d',
+        'clientSecret' => 'GXc8Q~mgI7kTBllrvpBthUEioeARdjrRYORSyda4',
+        'pkceMethod' => 'S256',
+    ],
+
 
     // This is a authentication source which handles admin authentication.
     'admin' => array(

--- a/docs/PKCE.md
+++ b/docs/PKCE.md
@@ -1,0 +1,37 @@
+# PKCE support
+
+PKCE (Proof Key for Code Exchange) is an extension to the OAuth2 protocol that is used to secure the
+authorization code flow against CSRF (cross site request forgery) and code injection attacks.
+PKCE is recommended in almost all OAuth use cases. Some servers or operators require the clients to use PKCE.
+
+## Usage
+
+Enable PKCE by setting the `pkceMethod` configuration key to a valid method (only `S256` is recommended).
+Note: `plain` is also a valid method, but not recommended, see the link to 'thephpleague/oauth2-client' below for details.
+
+### Example configuration
+
+Below is an example demonstrating how to configure the `authoauth2` module for PKCE:
+
+```php
+// config/authsources.php
+
+$config = [
+    'my-oidc-auth-source' => [
+        'authoauth2:OpenIDConnect',
+
+        'issuer' => 'https://my-issuer',
+        'clientId' => 'client-id',
+        'clientSecret' => 'client-secret',
+        
+        // activate PKCE with the S256 method
+        'pkceMethod' => 'S256',
+    ]
+];
+```
+
+## Links
+
+- See https://github.com/thephpleague/oauth2-client/blob/master/docs/usage.md#authorization-code-grant-with-pkce
+  for implementation notes of the underlying library.
+- RFC 7636 for PKCE: https://datatracker.ietf.org/doc/html/rfc7636

--- a/src/Auth/Source/OAuth2.php
+++ b/src/Auth/Source/OAuth2.php
@@ -12,7 +12,6 @@ use InvalidArgumentException;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use League\OAuth2\Client\Token\AccessToken;
-use League\OAuth2\Client\Token\AccessTokenInterface;
 use Psr\Http\Message\RequestInterface;
 use SimpleSAML\Auth\Source;
 use SimpleSAML\Auth\State;
@@ -23,7 +22,7 @@ use SimpleSAML\Module\authoauth2\AttributeManipulator;
 use SimpleSAML\Module\authoauth2\ConfigTemplate;
 use SimpleSAML\Module\authoauth2\locators\HTTPLocator;
 use SimpleSAML\Module\authoauth2\Providers\AdjustableGenericProvider;
-use SimpleSAML\Utils\HTTP;
+use SimpleSAML\Session;
 
 /**
  * Authenticate using Oauth2.
@@ -48,6 +47,9 @@ class OAuth2 extends Source
      */
     // phpcs:ignore
     public const DEBUG_LOG_FORMAT = "{method} {uri} {code} {req_headers_Authorization} >>>>'{req_body}' <<<<'{res_body}'";
+
+    private const PKCE_SESSION_NAMESPACE = 'authoauth2_pkce';
+    private const PKCE_SESSION_KEY = 'pkceCode';
 
     protected static string $defaultProviderClass = AdjustableGenericProvider::class;
 
@@ -123,6 +125,9 @@ class OAuth2 extends Source
         $options['state'] = self::STATE_PREFIX . '|' . $stateID;
         $authorizeURL = $provider->getAuthorizationUrl($options);
         Logger::debug("authoauth2: $providerLabel redirecting to authorizeURL=$authorizeURL");
+
+        // save the pkce code in the current session, so it can be retrieved later for verification
+        $this->saveCodeChallengeFromProvider($provider);
 
         $this->getHttp()->redirectTrustedURL($authorizeURL);
     }
@@ -205,6 +210,10 @@ class OAuth2 extends Source
         $providerLabel = $this->getLabel();
 
         $provider = $this->getProvider($this->config);
+
+        // load the pkce code from the session, so the server can validate it
+        // when exchanging the authorization code for an access token.
+        $this->loadCodeChallengeIntoProvider($provider);
 
         /**
          * @var AccessToken $accessToken
@@ -357,6 +366,47 @@ class OAuth2 extends Source
             return null;
         }
         return $decoded;
+    }
+
+    protected function isPkceEnabled(): bool
+    {
+        return (bool)$this->config->getOptionalValueValidate('pkceMethod', [
+            AbstractProvider::PKCE_METHOD_PLAIN,
+            AbstractProvider::PKCE_METHOD_S256,
+            ''
+        ], null);
+    }
+
+    /**
+     * support saving the providers PKCE code in the session for later verification.
+     */
+    protected function saveCodeChallengeFromProvider(AbstractProvider $provider): void
+    {
+        if ($this->isPkceEnabled()) {
+            Session::getSessionFromRequest()
+                ->setData(
+                    self::PKCE_SESSION_NAMESPACE,
+                    self::PKCE_SESSION_KEY,
+                    $provider->getPkceCode()
+                );
+        }
+    }
+
+    /**
+     * support retrieving the PKCE code from the session for verification.
+     */
+    protected function loadCodeChallengeIntoProvider(AbstractProvider $provider): void
+    {
+        if ($this->isPkceEnabled()) {
+            $pkceCode = (string)Session::getSessionFromRequest()
+                ->getData(
+                    self::PKCE_SESSION_NAMESPACE,
+                    self::PKCE_SESSION_KEY
+                );
+            if ($pkceCode) {
+                $provider->setPkceCode($pkceCode);
+            }
+        }
     }
 
     /**

--- a/src/Auth/Source/OAuth2.php
+++ b/src/Auth/Source/OAuth2.php
@@ -379,6 +379,9 @@ class OAuth2 extends Source
 
     /**
      * support saving the providers PKCE code in the session for later verification.
+     * We store in the session rather in the $state since the $provider generates
+     * the pkce after it has been configured with the $state id, which we get after
+     * saving the $state.
      */
     protected function saveCodeChallengeFromProvider(AbstractProvider $provider): void
     {

--- a/src/Providers/OpenIDConnectProvider.php
+++ b/src/Providers/OpenIDConnectProvider.php
@@ -26,6 +26,8 @@ class OpenIDConnectProvider extends AbstractProvider
 
     protected string $discoveryUrl;
 
+    protected ?string $pkceMethod = null;
+
     /**
      * @var ?Configuration
      */
@@ -257,5 +259,10 @@ class OpenIDConnectProvider extends AbstractProvider
     {
         $config = $this->getOpenIDConfiguration();
         return $config->getOptionalString("end_session_endpoint", null);
+    }
+
+    protected function getPkceMethod(): ?string
+    {
+        return $this->pkceMethod ?: parent::getPkceMethod();
     }
 }

--- a/tests/lib/MockOAuth2Provider.php
+++ b/tests/lib/MockOAuth2Provider.php
@@ -54,6 +54,16 @@ class MockOAuth2Provider extends GenericProvider implements ClearableState
         return self::$delegate->getParsedResponse($request);
     }
 
+    public function setPkceCode($pkceCode): void
+    {
+        self::$delegate->setPkceCode($pkceCode);
+    }
+
+    public function getPkceCode()
+    {
+        return self::$delegate->getPkceCode();
+    }
+
     /**
      * Clear any cached internal state.
      */

--- a/tests/lib/Providers/OpenIDConnectProviderTest.php
+++ b/tests/lib/Providers/OpenIDConnectProviderTest.php
@@ -96,4 +96,26 @@ class OpenIDConnectProviderTest extends TestCase
             $provider->getDiscoveryUrl()
         );
     }
+
+    public function testGetPkceMethodGetsSetFromConfig(): void
+    {
+        $provider = new OpenIDConnectProvider(
+            ['issuer' => 'https://accounts.example.com']
+        );
+        // make the protected getPkceMethod available
+        $reflection = new \ReflectionClass($provider);
+        $method = $reflection->getMethod('getPkceMethod');
+        $method->setAccessible(true);
+        $this->assertNull($method->invoke($provider));
+
+        $provider = new OpenIDConnectProvider([
+            'issuer' => 'https://accounts.example.com',
+            'pkceMethod' => 'S256'
+        ]);
+        // make the protected getPkceMethod available
+        $reflection = new \ReflectionClass($provider);
+        $method = $reflection->getMethod('getPkceMethod');
+        $method->setAccessible(true);
+        $this->assertEquals('S256', $method->invoke($provider));
+    }
 }


### PR DESCRIPTION
Added support for PKCE (extracted from PR #86 and reduced to the minimum).

PKCE was implemented via the underlying library. For that I had to increase the minimum version for
league/oauth2-client to 2.7. I think this should be fine, as there seems not to be any dependency
differences between 2.6 and 2.7.

- [x] Test added
- [x] Documentation added; Note: `README.md` and `CHANGELOG.md` not updated
- [x] Tests pass
- [x] `composer run validate` passes