### PR TITLE
feat(openIDConnect): add support for custom userInfoEndpoint (override).

### DIFF
--- a/simplesamlphp-module-authoauth2.iml
+++ b/simplesamlphp-module-authoauth2.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/Providers/OpenIDConnectProvider.php
+++ b/src/Providers/OpenIDConnectProvider.php
@@ -45,6 +45,8 @@ class OpenIDConnectProvider extends AbstractProvider
 
     protected bool $validateIssuer = false;
 
+    protected ?string $urlResourceOwnerDetails = null;
+
     public function __construct(array $options = [], array $collaborators = [])
     {
         parent::__construct($options, $collaborators);
@@ -57,6 +59,7 @@ class OpenIDConnectProvider extends AbstractProvider
         );
         $this->defaultScopes = $optionsConfig->getOptionalArray('scopes', ['openid', 'profile']);
         $this->validateIssuer = $optionsConfig->getOptionalBoolean('validateIssuer', true);
+        $this->urlResourceOwnerDetails = $optionsConfig->getOptionalString('urlResourceOwnerDetails', null);
     }
 
     /**
@@ -252,7 +255,7 @@ class OpenIDConnectProvider extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return $this->getOpenIDConfiguration()->getString("userinfo_endpoint");
+        return $this->urlResourceOwnerDetails ?? $this->getOpenIDConfiguration()->getString("userinfo_endpoint");
     }
 
     public function getEndSessionEndpoint(): ?string


### PR DESCRIPTION
I love using the openIDConnect standard, the problem is that my userinfo is actually hosted on a prem service and not within EntraID.
Meaning that I would need to use a custom OAuth2 provider.
But then I would lose the advantages with openIDConnect offers.
Support for logout and the discovery service being the most important ones.

By providing a custom/override for userInfoEndpoint/urlResourceOwnerDetails openIDConnect, I can use the best of both worlds and with minimal configuration support my own resource provider.

I looked into creating my own openIDConnect provider, but then for this small change I would need to add additional dependency.
While using the native module is much cleaner.

Thank you for having a look.