### PR TITLE
Fix missing $_SERVER['REQUEST_URI']  in unit test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
   "config": {
     "allow-plugins": {
       "simplesamlphp/composer-module-installer": true,
-      "dealerdirect/phpcodesniffer-composer-installer": false
+      "dealerdirect/phpcodesniffer-composer-installer": false,
+      "simplesamlphp/composer-xmlprovider-installer": false
     }
   },
   "suggest": {

--- a/tests/lib/Auth/Source/OAuth2Test.php
+++ b/tests/lib/Auth/Source/OAuth2Test.php
@@ -115,6 +115,7 @@ class OAuth2Test extends TestCase
      */
     public function testAuthenticatePerformsRedirect($config, $state, $expectedUrl)
     {
+        $_SERVER['REQUEST_URI'] = '/dummy';
         // Override redirect behavior
         $http = $this->createMock(HTTP::class);
         $http->method('redirectTrustedURL')


### PR DESCRIPTION
The test requires a dummy variable to be set for $_SERVER['REQUEST_URI']