### PR TITLE
Support SimpleSAMLphp 2.5 (Symfony 7.x). Remove unmaintained Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "firebase/php-jwt": "^5.5|^6",
     "kevinrob/guzzle-cache-middleware": "^4.1.1",
     "psr/cache": "^1.0|^2.0|^3.0",
-    "symfony/cache": "^6.0|^5.0|^4.3|^3.4",
+    "symfony/cache": "^7.0|^6.0|^5.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Probably the smallest PR possible, but this allows `symfony/cache` version 7.x, which is what SimpleSAMLphp 2.5 will be based on. Both SimpleSAMLphp 2.5 and Symfony 7.4 are due to be released later this month.

This PR also removes support for `symfony/cache` version 3.x and 4.x, because they are no longer maintained by the Symfony project, and users should upgrade to at least 5.x.

I've been testing this against SimpleSAMLphp 2.5.0-rc2 and it works for me.

Closes #107 